### PR TITLE
Inherit reactions & fix PEP8

### DIFF
--- a/nextguild/__init__.py
+++ b/nextguild/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
+from channel import Channel
 from client import Client
 from embed import Embed
 from events import Events
 from message import Message
 from reaction import Reaction, CalendarReaction, ForumTopicCommentReaction
-from channel import Channel

--- a/nextguild/client.py
+++ b/nextguild/client.py
@@ -5,8 +5,8 @@ from datetime import datetime
 
 import requests
 
-from nextguild.message import Message
 from nextguild.embed import Embed
+from nextguild.message import Message
 
 
 class Client:

--- a/nextguild/events.py
+++ b/nextguild/events.py
@@ -37,7 +37,6 @@ class Events:
         self._webhook_update_handlers = []
         self.client = client
 
-
     def on_message(self, func):
         @wraps(func)
         def wrapper(message):
@@ -84,7 +83,6 @@ class Events:
 
         self._member_join_handlers.append(wrapper)
         return wrapper
-
 
     async def _handle_member_join(self, event_data):
         for handler in self._member_join_handlers:
@@ -237,7 +235,6 @@ class Events:
         self._channel_delete_handlers.append(wrapper)
         return wrapper
 
-
     async def _handle_delete_channel(self, event_data):
         channel = Channel(event_data)
         for handler in self._channel_delete_handlers:
@@ -255,7 +252,6 @@ class Events:
         channel = Channel(event_data)
         for handler in self._channel_update_handlers:
             await handler(channel)
-
 
     def on_webhook_create(self, func):
         @wraps(func)
@@ -282,11 +278,6 @@ class Events:
         webhook = Webhook(event_data)
         for handler in self._webhook_update_handlers:
             await handler(webhook)
-
-
-
-
-
 
     async def start(self):
         async with websockets.connect(
@@ -342,5 +333,3 @@ class Events:
         except KeyboardInterrupt:
             # TODO Handle standard exit
             pass
-
-

--- a/nextguild/events.py
+++ b/nextguild/events.py
@@ -46,8 +46,8 @@ class Events:
         self._message_create_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_create_message(self, eventData):
-        message = Message(eventData)
+    async def _handle_create_message(self, event_data):
+        message = Message(event_data)
         for handler in self._message_create_handlers:
             await handler(message)
 
@@ -59,8 +59,8 @@ class Events:
         self._message_update_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_update_message(self, eventData):
-        message = Message(eventData)
+    async def _handle_update_message(self, event_data):
+        message = Message(event_data)
         for handler in self._message_update_handlers:
             await handler(message)
 
@@ -72,8 +72,8 @@ class Events:
         self._message_delete_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_delete_message(self, eventData):
-        message = Message(eventData)
+    async def _handle_delete_message(self, event_data):
+        message = Message(event_data)
         for handler in self._message_delete_handlers:
             await handler(message)
 
@@ -86,9 +86,9 @@ class Events:
         return wrapper
 
 
-    async def _handle_member_join(self, eventData):
+    async def _handle_member_join(self, event_data):
         for handler in self._member_join_handlers:
-            await handler(eventData)
+            await handler(event_data)
 
     def on_member_leave(self, func):
         @wraps(func)
@@ -98,9 +98,9 @@ class Events:
         self._member_leave_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_member_leave(self, eventData):
+    async def _handle_member_leave(self, event_data):
         for handler in self._member_leave_handlers:
-            await handler(eventData)
+            await handler(event_data)
 
     def on_member_banned(self, func):
         @wraps(func)
@@ -110,9 +110,9 @@ class Events:
         self._member_banned_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_member_banned(self, eventData):
+    async def _handle_member_banned(self, event_data):
         for handler in self._member_banned_handlers:
-            await handler(eventData)
+            await handler(event_data)
 
     def on_member_unbanned(self, func):
         @wraps(func)
@@ -122,9 +122,9 @@ class Events:
         self._member_unbanned_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_member_unbanned(self, eventData):
+    async def _handle_member_unbanned(self, event_data):
         for handler in self._member_unbanned_handlers:
-            await handler(eventData)
+            await handler(event_data)
 
     def on_ready(self, func):
         @wraps(func)
@@ -146,8 +146,8 @@ class Events:
         self._reaction_create_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_create_reaction(self, eventData):
-        reaction = Reaction(eventData)
+    async def _handle_create_reaction(self, event_data):
+        reaction = Reaction(event_data)
         for handler in self._reaction_create_handlers:
             await handler(reaction)
 
@@ -159,8 +159,8 @@ class Events:
         self._reaction_delete_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_delete_reaction(self, eventData):
-        reaction = Reaction(eventData)
+    async def _handle_delete_reaction(self, event_data):
+        reaction = Reaction(event_data)
         for handler in self._reaction_delete_handlers:
             await handler(reaction)
 
@@ -172,8 +172,8 @@ class Events:
         self._forum_topic_comment_reaction_create_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_forum_topic_comment_reaction_create(self, eventData):
-        reaction = ForumTopicCommentReaction(eventData)
+    async def _handle_forum_topic_comment_reaction_create(self, event_data):
+        reaction = ForumTopicCommentReaction(event_data)
         for handler in self._forum_topic_comment_reaction_create_handlers:
             await handler(reaction)
 
@@ -185,8 +185,8 @@ class Events:
         self._forum_topic_comment_reaction_delete_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_forum_topic_comment_reaction_delete(self, eventData):
-        reaction = ForumTopicCommentReaction(eventData)
+    async def _handle_forum_topic_comment_reaction_delete(self, event_data):
+        reaction = ForumTopicCommentReaction(event_data)
         for handler in self._forum_topic_comment_reaction_delete_handlers:
             await handler(reaction)
 
@@ -198,8 +198,8 @@ class Events:
         self._calendar_event_reaction_create_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_calendar_event_reaction_create(self, eventData):
-        reaction = CalendarReaction(eventData)
+    async def _handle_calendar_event_reaction_create(self, event_data):
+        reaction = CalendarReaction(event_data)
         for handler in self._calendar_event_reaction_create_handlers:
             await handler(reaction)
 
@@ -211,8 +211,8 @@ class Events:
         self._calendar_event_reaction_delete_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_calendar_event_reaction_delete(self, eventData):
-        reaction = CalendarReaction(eventData)
+    async def _handle_calendar_event_reaction_delete(self, event_data):
+        reaction = CalendarReaction(event_data)
         for handler in self._calendar_event_reaction_delete_handlers:
             await handler(reaction)
 
@@ -224,11 +224,10 @@ class Events:
         self._channel_create_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_create_channel(self, eventData):
-      channel = Channel(eventData)
-      for handler in self._channel_create_handlers:
-        await handler(channel)
-
+    async def _handle_create_channel(self, event_data):
+        channel = Channel(event_data)
+        for handler in self._channel_create_handlers:
+            await handler(channel)
 
     def on_channel_delete(self, func):
         @wraps(func)
@@ -239,8 +238,8 @@ class Events:
         return wrapper
 
 
-    async def _handle_delete_channel(self, eventData):
-        channel = Channel(eventData)
+    async def _handle_delete_channel(self, event_data):
+        channel = Channel(event_data)
         for handler in self._channel_delete_handlers:
             await handler(channel)
 
@@ -252,8 +251,8 @@ class Events:
         self._channel_update_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_update_channel(self, eventData):
-        channel = Channel(eventData)
+    async def _handle_update_channel(self, event_data):
+        channel = Channel(event_data)
         for handler in self._channel_update_handlers:
             await handler(channel)
 
@@ -266,8 +265,8 @@ class Events:
         self._webhook_create_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_create_webhook(self, eventData):
-        webhook = Webhook(eventData)
+    async def _handle_create_webhook(self, event_data):
+        webhook = Webhook(event_data)
         for handler in self._webhook_create_handlers:
             await handler(webhook)
 
@@ -279,8 +278,8 @@ class Events:
         self._webhook_update_handlers.append(wrapper)
         return wrapper
 
-    async def _handle_update_webhook(self, eventData):
-        webhook = Webhook(eventData)
+    async def _handle_update_webhook(self, event_data):
+        webhook = Webhook(event_data)
         for handler in self._webhook_update_handlers:
             await handler(webhook)
 
@@ -298,7 +297,7 @@ class Events:
                 json_data = json.loads(data)
 
                 if 't' in json_data and 'd' in json_data:
-                    eventType, eventData = json_data['t'], json_data['d']
+                    event_type, event_data = json_data['t'], json_data['d']
                 else:
                     continue
 
@@ -323,9 +322,9 @@ class Events:
                     'ServerWebhookUpdated': self._handle_update_webhook
 
                 }
-                handler = event_handlers.get(eventType)
+                handler = event_handlers.get(event_type)
                 if handler:
-                    await handler(eventData)
+                    await handler(event_data)
 
     def run(self):
         try:

--- a/nextguild/events.py
+++ b/nextguild/events.py
@@ -5,11 +5,10 @@ from functools import wraps
 
 import websockets
 
-from nextguild.client import Client
-from nextguild.message import Message, Webhook
-from nextguild.reaction import Reaction, CalendarReaction, ForumTopicComentReaction
 from nextguild.channel import Channel
-
+from nextguild.message import Message, Webhook
+from nextguild.reaction import Reaction, CalendarReaction, \
+    ForumTopicCommentReaction
 
 
 class Events:

--- a/nextguild/events.py
+++ b/nextguild/events.py
@@ -289,8 +289,12 @@ class Events:
 
 
     async def start(self):
-        async with websockets.connect('wss://www.guilded.gg/websocket/v1',
-                                      extra_headers={'Authorization': f'Bearer {self.client.token}'}) as websocket:
+        async with websockets.connect(
+                'wss://www.guilded.gg/websocket/v1',
+                extra_headers={
+                    'Authorization': f'Bearer {self.client.token}'
+                }
+        ) as websocket:
             await self._handle_ready()
             while True:
                 data = await websocket.recv()
@@ -309,12 +313,18 @@ class Events:
                     'ServerMemberRemoved': self._handle_member_leave,
                     'ServerMemberBanned': self._handle_member_banned,
                     'ServerMemberUnbanned': self._handle_member_unbanned,
-                    'ChannelMessageReactionCreated': self._handle_create_reaction,
-                    'ChannelMessageReactionDeleted': self._handle_delete_reaction,
-                    'ForumTopicCommentReactionCreated': self._handle_forum_topic_comment_reaction_create,
-                    'ForumTopicCommentReactionDeleted': self._handle_forum_topic_comment_reaction_delete,
-                    'CalendarEventReactionCreated': self._handle_calendar_event_reaction_create,
-                    'CalendarEventReactionDeleted': self._handle_calendar_event_reaction_delete,
+                    'ChannelMessageReactionCreated':
+                        self._handle_create_reaction,
+                    'ChannelMessageReactionDeleted':
+                        self._handle_delete_reaction,
+                    'ForumTopicCommentReactionCreated':
+                        self._handle_forum_topic_comment_reaction_create,
+                    'ForumTopicCommentReactionDeleted':
+                        self._handle_forum_topic_comment_reaction_delete,
+                    'CalendarEventReactionCreated':
+                        self._handle_calendar_event_reaction_create,
+                    'CalendarEventReactionDeleted':
+                        self._handle_calendar_event_reaction_delete,
                     'ServerChannelCreated': self._handle_create_channel,
                     'ServerChannelDeleted': self._handle_delete_channel,
                     'ServerChannelUpdated': self._handle_update_channel,

--- a/nextguild/example_bot.py
+++ b/nextguild/example_bot.py
@@ -10,9 +10,11 @@ if __name__ == '__main__':
     client = Client(BOT_TOKEN)
     events = Events(client)
 
+
     @events.on_ready
     async def on_ready():
         print('Ready!')
+
 
     @events.on_message
     async def ping_command(message: Message):

--- a/nextguild/message.py
+++ b/nextguild/message.py
@@ -36,8 +36,6 @@ class Message:
     async def reply(self):  # TODO "reply" method
         pass
 
-    
-          
 
 class Webhook:
     def __init__(self, event_data: dict):

--- a/nextguild/reaction.py
+++ b/nextguild/reaction.py
@@ -10,28 +10,17 @@ class Reaction:
         self.emote_url: str = event_data.get('reaction', {}).get('emote', {}).get('url')
 
 
-class CalendarReaction:
+class CalendarReaction(Reaction):
     def __init__(self, event_data: dict):
-        self.event_data: dict = event_data
-        self.server_id: str = event_data.get('serverId')
-        self.channel_id: str = event_data.get('reaction', {}).get('channelId')
-        self.user_id: str = event_data.get('reaction', {}).get('createdBy')
-        self.emote_name: str = event_data.get('reaction', {}).get('emote', {}).get('name')
-        self.emote_id: str = event_data.get('reaction', {}).get('emote', {}).get('id')
         self.emote_url: str = event_data.get('reaction', {}).get('emote', {}).get('url')
         self.calendar_event_id: str = event_data.get('reaction', {}).get('calendarEventId')
+        super().__init__(event_data)
 
           
-class ForumTopicCommentReaction:
-    def __init__(self, event_data: dict):
-        self.event_data: dict = event_data
-        self.server_id: str = event_data.get('serverId')
-        self.channel_id: str = event_data.get('reaction', {}).get('channelId')
-        self.user_id: str = event_data.get('reaction', {}).get('createdBy')
-        self.emote_name: str = event_data.get('reaction', {}).get('emote', {}).get('name')
-        self.emote_id: str = event_data.get('reaction', {}).get('emote', {}).get('id')
-        self.emote_url: str = event_data.get('reaction', {}).get('emote', {}).get('url')
         self.forum_topic_id: str = event_data.get('reaction', {}).get('forumTopicId')
         self.forum_topic_comment_id: str = event_data.get('reaction', {}).get('forumTopicCommentId')
 
  
+class ForumTopicCommentReaction(Reaction):
+    def __init__(self, event_data: dict):
+        super().__init__(event_data)

--- a/nextguild/reaction.py
+++ b/nextguild/reaction.py
@@ -5,22 +5,36 @@ class Reaction:
         self.server_id: str = event_data.get('serverId')
         self.channel_id: str = event_data.get('reaction', {}).get('channelId')
         self.user_id: str = event_data.get('reaction', {}).get('createdBy')
-        self.emote_name: str = event_data.get('reaction', {}).get('emote', {}).get('name')
-        self.emote_id: str = event_data.get('reaction', {}).get('emote', {}).get('id')
-        self.emote_url: str = event_data.get('reaction', {}).get('emote', {}).get('url')
+        self.emote_name: str = event_data.get('reaction', {}).get(
+            'emote', {}
+        ).get('name')
+        self.emote_id: str = event_data.get('reaction', {}).get(
+            'emote', {}
+        ).get('id')
+        self.emote_url: str = event_data.get('reaction', {}).get(
+            'emote', {}
+        ).get('url')
 
 
 class CalendarReaction(Reaction):
     def __init__(self, event_data: dict):
-        self.emote_url: str = event_data.get('reaction', {}).get('emote', {}).get('url')
-        self.calendar_event_id: str = event_data.get('reaction', {}).get('calendarEventId')
         super().__init__(event_data)
+        self.emote_url: str = event_data.get('reaction', {}).get(
+            'emote', {}
+        ).get('url')
+        self.calendar_event_id: str = event_data.get('reaction', {}).get(
+            'calendarEventId'
+        )
 
           
-        self.forum_topic_id: str = event_data.get('reaction', {}).get('forumTopicId')
-        self.forum_topic_comment_id: str = event_data.get('reaction', {}).get('forumTopicCommentId')
 
  
 class ForumTopicCommentReaction(Reaction):
     def __init__(self, event_data: dict):
         super().__init__(event_data)
+        self.forum_topic_id: str = event_data.get(
+            'reaction', {}
+        ).get('forumTopicId')
+        self.forum_topic_comment_id: str = event_data.get(
+            'reaction', {}
+        ).get('forumTopicCommentId')

--- a/nextguild/reaction.py
+++ b/nextguild/reaction.py
@@ -26,9 +26,7 @@ class CalendarReaction(Reaction):
             'calendarEventId'
         )
 
-          
 
- 
 class ForumTopicCommentReaction(Reaction):
     def __init__(self, event_data: dict):
         super().__init__(event_data)


### PR DESCRIPTION
# General

- Add inheritance of `Reaction` class.

# PEP8

- Imports should be split to three categories: built-ins, required, own.
- Imports should be sorted alphabetically.
- Python uses `snake_case`.
- Lines should be seventy-nine characters long or less.
- Between classes and functions there should be two empty lines (except inside statements like `if` or `with`). Everywhere else one or none.